### PR TITLE
docs: fix dead link to Camunda Connector Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mvn clean verify
 ### Test as local Job Worker
 
 Use
-the [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-framework/tree/main/runtime-job-worker)
+the [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles)
 to run your function as a local Job Worker.
 
 ## Element Template


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Fixes the link in [`README.md`](https://github.com/camunda-community-hub/connector-rocketmq/blob/ac565c2e79f2b95a647ad72fe9bd9660171144ef/README.md?plain=1#L57) to [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles). This is similar to:
- camunda/connector-sendgrid#139
- camunda/connector-slack#139
- camunda/connector-google-drive#113
- camunda-community-hub/camunda-8-connector-openweather-api#1

## Related issues

<!-- Which issues are closed by this PR or are related -->
No related issue.

